### PR TITLE
Cast to RelativeLayout

### DIFF
--- a/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
+++ b/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
@@ -93,7 +93,7 @@ public class ProductListAdapter {
     }
 
     public void updateItem(int index, Product newItem) {
-        LinearLayout listItem = (LinearLayout) productListLayout.getChildAt(index);
+        RelativeLayout listItem = (RelativeLayout) productListLayout.getChildAt(index);
         CheckBox itemCheckBox = listItem.findViewById(R.id.list_item_check_box);
 
         itemCheckBox.setText(newItem.getName());


### PR DESCRIPTION
Updating an item would crash because of a cast type which wasn't updated when one of the layout types was changed.

- Cast to `RelativeLayout` instead of old `LinearLayout`

![](https://media.giphy.com/media/CF1PeWOAv68la/giphy.gif)