### PR TITLE
Stop list item text overlap

### DIFF
--- a/app/src/main/res/layout/product_list_item_layout.xml
+++ b/app/src/main/res/layout/product_list_item_layout.xml
@@ -8,10 +8,10 @@
 
     <CheckBox
         android:id="@+id/list_item_check_box"
-        android:layout_width="wrap_content"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
+        android:layout_toStartOf="@+id/delete_product_button"
+        android:layout_toLeftOf="@+id/delete_product_button"
         android:text="@string/quantity_product_name"
         android:textAppearance="@style/ListItemText"
         android:textColor="@color/colorBodyText" />

--- a/app/src/main/res/layout/shopping_list_item_layout.xml
+++ b/app/src/main/res/layout/shopping_list_item_layout.xml
@@ -11,8 +11,8 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:text="@string/list_name"
-        android:layout_toStartOf="@+id/delete_product_button"
-        android:layout_toLeftOf="@+id/delete_product_button"
+        android:layout_toStartOf="@+id/delete_list_button"
+        android:layout_toLeftOf="@+id/delete_list_button"
         android:textAppearance="@style/ListItemText" />
 
     <ImageButton

--- a/app/src/main/res/layout/shopping_list_item_layout.xml
+++ b/app/src/main/res/layout/shopping_list_item_layout.xml
@@ -8,11 +8,11 @@
 
     <TextView
         android:id="@+id/list_select_list_name"
-        android:layout_width="wrap_content"
+        android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:text="@string/list_name"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true"
+        android:layout_toStartOf="@+id/delete_product_button"
+        android:layout_toLeftOf="@+id/delete_product_button"
         android:textAppearance="@style/ListItemText" />
 
     <ImageButton


### PR DESCRIPTION
Previously, if you made a list name or item name really long, it'd overlap the delete button to the right. 
This fixes it afaik

- Set widths in items and lists to `fill_parent`
- Align text to left of delete button

![](https://media.giphy.com/media/xT9IgK5yUSiW8UdqkE/giphy.gif)