### PR TITLE
Editable list item names

### DIFF
--- a/app/src/main/java/kres/listyMcListFace/activities/ProductListActivity.java
+++ b/app/src/main/java/kres/listyMcListFace/activities/ProductListActivity.java
@@ -14,6 +14,7 @@ import com.google.firebase.database.DatabaseReference;
 import com.google.gson.Gson;
 
 import kres.listyMcListFace.R;
+import kres.listyMcListFace.dialog.editProduct.EditProductDialogListener;
 import kres.listyMcListFace.firebase.util.FirebaseRefs;
 import kres.listyMcListFace.firebase.productList.ProductListChangeListener;
 import kres.listyMcListFace.firebase.productList.ProductListManager;
@@ -25,7 +26,7 @@ import kres.listyMcListFace.dialog.newProduct.NewProductDialog;
 import kres.listyMcListFace.dialog.newProduct.NewProductDialogListener;
 import kres.listyMcListFace.model.Product;
 
-public class ProductListActivity extends AppCompatActivity implements NewProductDialogListener {
+public class ProductListActivity extends AppCompatActivity implements NewProductDialogListener, EditProductDialogListener {
 
     private String listID;
 
@@ -67,6 +68,12 @@ public class ProductListActivity extends AppCompatActivity implements NewProduct
     public void onProductAdded(Product product) {
         Log.d("PRODUCT_ADDED", "" + product.getName());
         ProductListManager.addItem(listID, product);
+    }
+
+    @Override
+    public void onProductNameUpdated(Product product) {
+        Log.d("PRODUCT_UPDATED", "" + product.getName());
+        ProductListManager.editItem(listID, product);
     }
 
     @Override

--- a/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
+++ b/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
@@ -1,0 +1,74 @@
+package kres.listyMcListFace.dialog.editProduct;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+
+import kres.listyMcListFace.R;
+import kres.listyMcListFace.dialog.DialogShowListener;
+import kres.listyMcListFace.model.Product;
+import kres.listyMcListFace.util.Constants;
+
+public class EditProductDialog extends DialogFragment {
+
+    private EditProductDialogListener listener;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        LayoutInflater inflater = getActivity().getLayoutInflater();
+
+        View dialogView = inflater.inflate(R.layout.dialog_edit_product, null);
+
+        final EditText editText = dialogView.findViewById(R.id.product_name_edit_text);
+        String existingProductName = getArguments().getString(Constants.EDIT_DIALOG_PRODUCT_NAME_KEY);
+        editText.setText(existingProductName);
+
+        builder.setView(dialogView);
+
+        builder.setPositiveButton("Add", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                Log.d("NEW_PRODUCT_DIALOG", "Positive button clicked");
+
+                String productName = editText.getText().toString();
+                Product product = new Product(productName);
+
+                listener.onProductNameUpdated(product);
+            }
+        });
+
+        builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                Log.d("NEW_PRODUCT_DIALOG", "Negative button clicked");
+                listener.onCancel();
+            }
+        });
+
+        AlertDialog alertDialog = builder.create();
+        alertDialog.setOnShowListener(new DialogShowListener(getActivity(), alertDialog));
+
+        return alertDialog;
+    }
+
+    @Override
+    public void onAttach(Activity activity) {
+        super.onAttach(activity);
+        // Verify that the host activity implements the callback interface
+        try {
+            // Instantiate the NoticeDialogListener so we can send events to the host
+            listener = (EditProductDialogListener) activity;
+        } catch (ClassCastException e) {
+            // The activity doesn't implement the interface, throw exception
+            throw new ClassCastException(activity.toString() + " must implement NewProductDialogListener");
+        }
+    }
+}

--- a/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
+++ b/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
@@ -33,10 +33,10 @@ public class EditProductDialog extends DialogFragment {
 
         builder.setView(dialogView);
 
-        builder.setPositiveButton("Add", new DialogInterface.OnClickListener() {
+        builder.setPositiveButton("Update", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
-                Log.d("NEW_PRODUCT_DIALOG", "Positive button clicked");
+                Log.d("EDIT_PRODUCT_DIALOG", "Positive button clicked");
 
                 String productName = editText.getText().toString();
                 Product product = new Product(productName);
@@ -48,7 +48,7 @@ public class EditProductDialog extends DialogFragment {
         builder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
-                Log.d("NEW_PRODUCT_DIALOG", "Negative button clicked");
+                Log.d("EDIT_PRODUCT_DIALOG", "Negative button clicked");
                 listener.onCancel();
             }
         });
@@ -68,7 +68,7 @@ public class EditProductDialog extends DialogFragment {
             listener = (EditProductDialogListener) activity;
         } catch (ClassCastException e) {
             // The activity doesn't implement the interface, throw exception
-            throw new ClassCastException(activity.toString() + " must implement NewProductDialogListener");
+            throw new ClassCastException(activity.toString() + " must implement EditProductDialogListener");
         }
     }
 }

--- a/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
+++ b/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialog.java
@@ -11,6 +11,8 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 
+import com.google.gson.Gson;
+
 import kres.listyMcListFace.R;
 import kres.listyMcListFace.dialog.DialogShowListener;
 import kres.listyMcListFace.model.Product;
@@ -28,8 +30,9 @@ public class EditProductDialog extends DialogFragment {
         View dialogView = inflater.inflate(R.layout.dialog_edit_product, null);
 
         final EditText editText = dialogView.findViewById(R.id.product_name_edit_text);
-        String existingProductName = getArguments().getString(Constants.EDIT_DIALOG_PRODUCT_NAME_KEY);
-        editText.setText(existingProductName);
+        String existingProductNameJSON = getArguments().getString(Constants.EDIT_DIALOG_EXISTING_PRODUCT_JSON);
+        final Product existingProduct = new Gson().fromJson(existingProductNameJSON, Product.class);
+        editText.setText(existingProduct.getName());
 
         builder.setView(dialogView);
 
@@ -39,9 +42,9 @@ public class EditProductDialog extends DialogFragment {
                 Log.d("EDIT_PRODUCT_DIALOG", "Positive button clicked");
 
                 String productName = editText.getText().toString();
-                Product product = new Product(productName);
+                existingProduct.setName(productName);
 
-                listener.onProductNameUpdated(product);
+                listener.onProductNameUpdated(existingProduct);
             }
         });
 

--- a/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialogListener.java
+++ b/app/src/main/java/kres/listyMcListFace/dialog/editProduct/EditProductDialogListener.java
@@ -1,0 +1,10 @@
+package kres.listyMcListFace.dialog.editProduct;
+
+import kres.listyMcListFace.model.Product;
+
+public interface EditProductDialogListener {
+
+    void onProductNameUpdated(Product product);
+    void onCancel();
+
+}

--- a/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
+++ b/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
@@ -1,6 +1,8 @@
 package kres.listyMcListFace.firebase.productList;
 
+import android.app.Activity;
 import android.content.Context;
+import android.app.DialogFragment;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -14,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import kres.listyMcListFace.R;
+import kres.listyMcListFace.dialog.editProduct.EditProductDialog;
 import kres.listyMcListFace.dialog.remove.DeleteProductDialog;
 import kres.listyMcListFace.model.Product;
 
@@ -80,6 +83,16 @@ public class ProductListAdapter {
             public void onClick(View v) {
                 DeleteProductDialog dialog = new DeleteProductDialog(context, listID, item.getID(), that);
                 dialog.show();
+            }
+        });
+
+        listItem.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(View v) {
+                DialogFragment dialog = new EditProductDialog();
+                Activity activity = (Activity)context;
+                dialog.show(activity.getFragmentManager(), "Edit Product");
+                return true;
             }
         });
 

--- a/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
+++ b/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
@@ -13,6 +13,8 @@ import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.RelativeLayout;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -93,7 +95,7 @@ public class ProductListAdapter {
             public boolean onLongClick(View v) {
                 DialogFragment dialog = new EditProductDialog();
                 Bundle bundle = new Bundle();
-                bundle.putString(Constants.EDIT_DIALOG_PRODUCT_NAME_KEY, item.getName());
+                bundle.putString(Constants.EDIT_DIALOG_EXISTING_PRODUCT_JSON, new Gson().toJson(item));
                 dialog.setArguments(bundle);
                 Activity activity = (Activity)context;
                 dialog.show(activity.getFragmentManager(), "Edit Product");

--- a/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
+++ b/app/src/main/java/kres/listyMcListFace/firebase/productList/ProductListAdapter.java
@@ -3,6 +3,7 @@ package kres.listyMcListFace.firebase.productList;
 import android.app.Activity;
 import android.content.Context;
 import android.app.DialogFragment;
+import android.os.Bundle;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -19,6 +20,7 @@ import kres.listyMcListFace.R;
 import kres.listyMcListFace.dialog.editProduct.EditProductDialog;
 import kres.listyMcListFace.dialog.remove.DeleteProductDialog;
 import kres.listyMcListFace.model.Product;
+import kres.listyMcListFace.util.Constants;
 
 public class ProductListAdapter {
 
@@ -86,10 +88,13 @@ public class ProductListAdapter {
             }
         });
 
-        listItem.setOnLongClickListener(new View.OnLongClickListener() {
+        itemCheckBox.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
                 DialogFragment dialog = new EditProductDialog();
+                Bundle bundle = new Bundle();
+                bundle.putString(Constants.EDIT_DIALOG_PRODUCT_NAME_KEY, item.getName());
+                dialog.setArguments(bundle);
                 Activity activity = (Activity)context;
                 dialog.show(activity.getFragmentManager(), "Edit Product");
                 return true;

--- a/app/src/main/java/kres/listyMcListFace/model/Product.java
+++ b/app/src/main/java/kres/listyMcListFace/model/Product.java
@@ -26,6 +26,10 @@ public class Product {
         return name;
     }
 
+    public void setName(String name) {
+        this.name = name;
+    }
+
     public boolean isBought() {
         return bought;
     }

--- a/app/src/main/java/kres/listyMcListFace/util/Constants.java
+++ b/app/src/main/java/kres/listyMcListFace/util/Constants.java
@@ -3,6 +3,6 @@ package kres.listyMcListFace.util;
 public class Constants {
 
     public static final String SHOPPING_LIST_INTENT_KEY = "SHOPPING_LIST";
-
+    public static final String EDIT_DIALOG_PRODUCT_NAME_KEY = "EDIT_DIALOG_PRODUCT_NAME";
 
 }

--- a/app/src/main/java/kres/listyMcListFace/util/Constants.java
+++ b/app/src/main/java/kres/listyMcListFace/util/Constants.java
@@ -3,6 +3,6 @@ package kres.listyMcListFace.util;
 public class Constants {
 
     public static final String SHOPPING_LIST_INTENT_KEY = "SHOPPING_LIST";
-    public static final String EDIT_DIALOG_PRODUCT_NAME_KEY = "EDIT_DIALOG_PRODUCT_NAME";
+    public static final String EDIT_DIALOG_EXISTING_PRODUCT_JSON = "EDIT_DIALOG_EXISTING_PRODUCT";
 
 }

--- a/app/src/main/res/layout/dialog_edit_product.xml
+++ b/app/src/main/res/layout/dialog_edit_product.xml
@@ -5,21 +5,24 @@
     android:layout_height="match_parent"
     android:gravity="center" >
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/edit_product_title_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal">
+        android:text="Update Item"
+        android:textAppearance="@style/TitleText"
+        android:textColor="@color/colorPrimary" />
 
-        <EditText
-            android:id="@+id/product_name_edit_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/product_name"
-            android:inputType="text"
-            android:textColor="@color/colorBodyText"
-            android:textColorHint="@color/colorHintText" />
-    </LinearLayout>
+    <EditText
+        android:id="@+id/product_name_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="10dp"
+        android:layout_marginStart="10dp"
+        android:ems="10"
+        android:hint="@string/product_name"
+        android:inputType="text"
+        android:textColor="@color/colorBodyText"
+        android:textColorHint="@color/colorHintText" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_edit_product.xml
+++ b/app/src/main/res/layout/dialog_edit_product.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="horizontal">
+
+        <EditText
+            android:id="@+id/product_name_edit_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:hint="@string/product_name"
+            android:inputType="text"
+            android:textColor="@color/colorBodyText"
+            android:textColorHint="@color/colorHintText" />
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_edit_product.xml
+++ b/app/src/main/res/layout/dialog_edit_product.xml
@@ -9,7 +9,9 @@
         android:id="@+id/edit_product_title_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Update Item"
+        android:paddingStart="10dp"
+        android:paddingTop="10dp"
+        android:text="@string/edit"
         android:textAppearance="@style/TitleText"
         android:textColor="@color/colorPrimary" />
 
@@ -17,8 +19,8 @@
         android:id="@+id/product_name_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="10dp"
-        android:layout_marginStart="10dp"
+        android:layout_marginEnd="15dp"
+        android:layout_marginStart="15dp"
         android:ems="10"
         android:hint="@string/product_name"
         android:inputType="text"

--- a/app/src/main/res/layout/dialog_new_product.xml
+++ b/app/src/main/res/layout/dialog_new_product.xml
@@ -5,21 +5,26 @@
     android:layout_height="match_parent"
     android:gravity="center" >
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/new_product_title_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:gravity="center"
-        android:orientation="horizontal">
+        android:paddingStart="10dp"
+        android:paddingTop="10dp"
+        android:text="@string/new_dialog_title"
+        android:textAppearance="@style/TitleText"
+        android:textColor="@color/colorPrimary" />
 
-        <EditText
-            android:id="@+id/product_name_edit_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:ems="10"
-            android:hint="@string/product_name"
-            android:inputType="text"
-            android:textColor="@color/colorBodyText"
-            android:textColorHint="@color/colorHintText" />
-    </LinearLayout>
+    <EditText
+        android:id="@+id/product_name_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="15dp"
+        android:layout_marginStart="15dp"
+        android:ems="10"
+        android:hint="@string/product_name"
+        android:inputType="text"
+        android:textColor="@color/colorBodyText"
+        android:textColorHint="@color/colorHintText" />
 
 </LinearLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#FF4081</color>
+    <color name="colorPrimary">#ff4081</color>
     <color name="colorPrimaryDark">#232C3D</color>
     <color name="colorAccent">#FF4081</color>
     <color name="colorBodyText">#ffffff</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,6 @@
     <string name="title_join">Join -</string>
     <string name="your_lists">Your lists</string>
     <string name="edit">Edit</string>
+    <string name="new">New</string>
+    <string name="new_dialog_title">New</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="title">Title</string>
     <string name="title_join">Join -</string>
     <string name="your_lists">Your lists</string>
+    <string name="edit">Edit</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,5 @@
     <string name="title_join">Join -</string>
     <string name="your_lists">Your lists</string>
     <string name="edit">Edit</string>
-    <string name="new">New</string>
     <string name="new_dialog_title">New</string>
 </resources>


### PR DESCRIPTION
Fixes: #66 

- Adds the `Edit` dialog for editing existing product names (on long click)
- Adds a title to the `New` dialog for products (to match Edit dialog)

![](https://media.giphy.com/media/3vc4sSq0l8AbS/giphy.gif)