### PR TITLE
Set textIsSelected to true for join code

### DIFF
--- a/app/src/main/res/layout/title_bar_layout.xml
+++ b/app/src/main/res/layout/title_bar_layout.xml
@@ -19,6 +19,7 @@
         android:id="@+id/title_bar_join_code"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:textIsSelectable="true"
         android:text="@string/title_join"
         android:textAppearance="@style/SubtitleText" />
 </LinearLayout>


### PR DESCRIPTION
Fixes: #64 

- Set `textIsSelected` to `true` for the join code `TextView`

![](https://media.giphy.com/media/3o7TKH8yWJ4X5iSDMQ/giphy.gif)