### PR TITLE
Capitalise product names

### DIFF
--- a/app/src/main/res/layout/dialog_edit_product.xml
+++ b/app/src/main/res/layout/dialog_edit_product.xml
@@ -23,7 +23,7 @@
         android:layout_marginStart="15dp"
         android:ems="10"
         android:hint="@string/product_name"
-        android:inputType="text"
+        android:inputType="textCapSentences"
         android:textColor="@color/colorBodyText"
         android:textColorHint="@color/colorHintText" />
 

--- a/app/src/main/res/layout/dialog_new_product.xml
+++ b/app/src/main/res/layout/dialog_new_product.xml
@@ -17,7 +17,7 @@
             android:layout_height="wrap_content"
             android:ems="10"
             android:hint="@string/product_name"
-            android:inputType="text"
+            android:inputType="textCapSentences"
             android:textColor="@color/colorBodyText"
             android:textColorHint="@color/colorHintText" />
     </LinearLayout>


### PR DESCRIPTION
Fixes: #62 

- Set `inputType` on edit and new product dialogs

![](https://media.giphy.com/media/UIKUeFj40vTP2/giphy-downsized.gif)